### PR TITLE
Design code guidelines - best practices

### DIFF
--- a/MVP/MVPUI/App.xaml
+++ b/MVP/MVPUI/App.xaml
@@ -1,106 +1,23 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Application xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:Microsoft.Mvpui.Converters;assembly=Mvpui"
-			  xmlns:mvpHelpers="clr-namespace:Microsoft.Mvp.Helpers;assembly=Mvp"
+             xmlns:local="clr-namespace:Microsoft.Mvpui;assembly=Mvpui"
+             xmlns:converters="clr-namespace:Microsoft.Mvpui.Converters;assembly=Mvpui"
+			 xmlns:xamlresources="clr-namespace:Microsoft.Mvpui.XamlResources;assembly=Mvpui"
+			 xmlns:mvpHelpers="clr-namespace:Microsoft.Mvp.Helpers;assembly=Mvp"
              x:Class="Microsoft.Mvpui.App">
     <Application.Resources>
 
-        <ResourceDictionary>
-            <local:ContributionToIconConverter x:Key="ContributionToIconConverter" />
+		<local:ResourceDictionary>
+			<local:ResourceDictionary.MergedDictionaries>
+				<xamlresources:Styles />
+				<xamlresources:DataTemplates />
+			</local:ResourceDictionary.MergedDictionaries>
+			
+			<converters:ContributionToIconConverter x:Key="ContributionToIconConverter" />
 			<mvpHelpers:TranslateExtensionConverter x:Key="TranslateExtensionConverter"/>
 
-			<Color x:Key="Primary">#0072C6</Color>
-			<Color x:Key="PrimaryDark">#004f8a</Color>
-			<Color x:Key="Accent">#FFC107</Color>
-			<Color x:Key="BlueBackgroundColor">#0072C6</Color>
-			<Color x:Key="BackgroundColoriOS">#FFFFFF</Color>
-
-			<OnPlatform x:Key="BackgroundColor" x:TypeArguments="Color">
-				<On Platform="iOS" Value="#FFFFFF" />
-				<On Platform="Android" Value="#F5F5F5" />
-				<On Platform="UWP" Value="#F5F5F5" />
-			</OnPlatform>
-
-			<Color x:Key="NavigationTintColor">#999fa5</Color>
-            <Color x:Key="NavigationTitleColor">#0a77b2</Color>
-            <Color x:Key="NavigationShadowColor">#f2f2f2</Color>
-            <Color x:Key="TabTintColor">#0078d7</Color>
-
-            <OnPlatform x:Key="NormalLabelFontSize" x:TypeArguments="x:Double">
-				<On Platform="iOS" Value="13" />
-				<On Platform="Android" Value="14" />
-				<On Platform="UWP" Value="14" />
-			</OnPlatform>
-
-            
-			<OnPlatform x:Key="BottomMenuLabelFontSize" x:TypeArguments="x:Double">
-				<On Platform="iOS" Value="10" />
-				<On Platform="Android" Value="12" />
-				<On Platform="UWP" Value="12" />
-			</OnPlatform>
-			<OnPlatform x:Key="ContributionBtnFontSize" x:TypeArguments="x:Double">
-				<On Platform="iOS" Value="10" />
-				<On Platform="Android" Value="16" />
-				<On Platform="UWP" Value="16" />
-			</OnPlatform>
-
-			<OnPlatform x:Key="CommonProfileLabelFontSize" x:TypeArguments="x:Double">
-				<On Platform="iOS" Value="12" />
-				<On Platform="Android" Value="14" />
-				<On Platform="UWP" Value="14" />
-			</OnPlatform>
-			<OnPlatform x:Key="SmallProfileLabelFontSize" x:TypeArguments="x:Double" >
-				<On Platform="iOS" Value="10" />
-				<On Platform="Android" Value="14" />
-				<On Platform="UWP" Value="14" />
-			</OnPlatform>
-			<OnPlatform x:Key="XSmallProfileLabelFontSize" x:TypeArguments="x:Double" >
-				<On Platform="iOS" Value="13" />
-				<On Platform="Android" Value="13" />
-				<On Platform="UWP" Value="13" />
-			</OnPlatform>
-
-            <Color x:Key="PrimaryTextColor">#818181</Color>
-            <Color x:Key="SecondaryTextColor">#4B4B4B</Color>
-
-            <Style TargetType="Label">
-                <Setter Property="FontFamily">
-                    <Setter.Value>
-                      <OnPlatform x:TypeArguments="x:String">
-                        <OnPlatform.iOS>HelveticaNeue</OnPlatform.iOS>
-                      </OnPlatform>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-            <Style TargetType="Button">
-                <Setter Property="FontFamily">
-                    <Setter.Value>
-                      <OnPlatform x:TypeArguments="x:String">
-                        <OnPlatform.iOS>HelveticaNeue-Bold</OnPlatform.iOS>
-                      </OnPlatform>
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="FontSize">
-                    <Setter.Value>
-                      <OnPlatform x:TypeArguments="x:Double">
-                        <OnPlatform.iOS>14</OnPlatform.iOS>
-                      </OnPlatform>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-            <Style TargetType="Label" x:Key="BoldLabel">
-                <Setter Property="FontFamily">
-                    <Setter.Value>
-                      <OnPlatform x:TypeArguments="x:String">
-                        <OnPlatform.iOS>HelveticaNeue-Bold</OnPlatform.iOS>
-                      </OnPlatform>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-            
-        </ResourceDictionary>
+		</local:ResourceDictionary>
 
     </Application.Resources>
 </Application>

--- a/MVP/MVPUI/Extensions/ResourceDictionaryExtensions.cs
+++ b/MVP/MVPUI/Extensions/ResourceDictionaryExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Microsoft.Mvpui
+{
+	internal static class MergeExtensions
+	{
+		internal static void ForEach<T>(this IEnumerable<T> items, Action<T> action)
+		{
+			foreach (var item in items) action(item);
+		}
+
+		internal static void Merge<TKey, TValue>(this IDictionary<TKey, TValue> targetDictionary,
+			IEnumerable<KeyValuePair<TKey, TValue>> sourceItems)
+		{
+			var targetItems = targetDictionary.ToArray();
+			sourceItems.ForEach(i => targetDictionary[i.Key] = i.Value);
+			targetItems.ForEach(i => targetDictionary[i.Key] = i.Value); // override merged by local values
+		}
+	}
+
+	public class ResourceDictionary : Xamarin.Forms.ResourceDictionary
+	{
+		public ResourceDictionary()
+		{
+			MergedDictionaries = new ObservableCollection<Xamarin.Forms.ResourceDictionary>();
+			MergedDictionaries.CollectionChanged += (sender, args) =>
+				(args.NewItems ?? new List<object>()).OfType<Xamarin.Forms.ResourceDictionary>()
+				.ForEach(this.Merge);
+		}
+
+		public ObservableCollection<Xamarin.Forms.ResourceDictionary> MergedDictionaries { get; }
+	}
+}

--- a/MVP/MVPUI/MVPUI.csproj
+++ b/MVP/MVPUI/MVPUI.csproj
@@ -58,6 +58,7 @@
     <Compile Include="CustomControls\ICookieHelper.cs" />
     <Compile Include="CustomControls\ILocationHelper.cs" />
     <Compile Include="CustomControls\MVPNavigationPage.cs" />
+    <Compile Include="Extensions\ResourceDictionaryExtensions.cs" />
     <Compile Include="LiveIdLogOn.xaml.cs">
       <DependentUpon>LiveIdLogOn.xaml</DependentUpon>
     </Compile>
@@ -78,6 +79,12 @@
       <DependentUpon>SettingsPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Converters\ContributionToIconConverter.cs" />
+    <Compile Include="XamlResources\DataTemplates.xaml.cs">
+      <DependentUpon>DataTemplates.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="XamlResources\Styles.xaml.cs">
+      <DependentUpon>Styles.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="LogOn.xaml">
@@ -206,6 +213,18 @@
     <EmbeddedResource Include="MainTabPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="XamlResources\Styles.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="XamlResources\DataTemplates.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/MVP/MVPUI/MyProfile.xaml
+++ b/MVP/MVPUI/MyProfile.xaml
@@ -28,25 +28,26 @@
 					<Label Text="{Binding LabelForAwardCategories}" HorizontalTextAlignment="Center" HorizontalOptions="Center" TextColor="{StaticResource PrimaryTextColor}" FontSize="10" FontAttributes="Bold" Style="{StaticResource BoldLabel}" />
                     <Label Text="{Binding AwardCategoriesValue}" HorizontalTextAlignment="Center" HorizontalOptions="Center" TextColor="{StaticResource SecondaryTextColor}" FontSize="14" FontAttributes="Bold" Style="{StaticResource BoldLabel}" />
 
-                    <Grid Margin="0,20,0,0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <StackLayout Margin="30,0,0,0" Grid.Column="0" Spacing="0" Orientation="Vertical">
-							<Label Text="{Binding LabelForFirstAward}" HorizontalTextAlignment="Center" HorizontalOptions="Center" TextColor="{StaticResource PrimaryTextColor}" FontSize="10" FontAttributes="Bold" Style="{StaticResource BoldLabel}" />    
-                            <Label Text="{Binding FirstAwardValue}" HorizontalTextAlignment="Center" HorizontalOptions="Center" TextColor="{StaticResource SecondaryTextColor}" FontSize="24" FontAttributes="Bold" Style="{StaticResource BoldLabel}" />
-                        </StackLayout>
-                        <StackLayout Margin="0,0,30,0" Grid.Column="1" Spacing="0" Orientation="Vertical">
-							<Label Text="{Binding LabelForNumberOfAward}" HorizontalTextAlignment="Center" HorizontalOptions="Center" TextColor="{StaticResource PrimaryTextColor}" FontSize="10" FontAttributes="Bold" Style="{StaticResource BoldLabel}" />    
-                            <Label Text="{Binding AwardsCountValue}" HorizontalTextAlignment="Center" HorizontalOptions="Center" TextColor="{StaticResource SecondaryTextColor}" FontSize="24" FontAttributes="Bold" Style="{StaticResource BoldLabel}" />
-                        </StackLayout>
-                    </Grid>
+					<Grid Margin="0,20,0,20">
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="*" />
+						</Grid.ColumnDefinitions>
+						<StackLayout Margin="30,0,0,0" Grid.Column="0" Spacing="0" Orientation="Vertical">
+							<Label Text="{Binding LabelForFirstAward}" HorizontalTextAlignment="Center" HorizontalOptions="Center" TextColor="{StaticResource PrimaryTextColor}" FontSize="10" FontAttributes="Bold" Style="{StaticResource BoldLabel}" />
+							<Label Text="{Binding FirstAwardValue}" HorizontalTextAlignment="Center" HorizontalOptions="Center" TextColor="{StaticResource SecondaryTextColor}" FontSize="24" FontAttributes="Bold" Style="{StaticResource BoldLabel}" />
+						</StackLayout>
+						<StackLayout Margin="0,0,30,0" Grid.Column="1" Spacing="0" Orientation="Vertical">
+							<Label Text="{Binding LabelForNumberOfAward}" HorizontalTextAlignment="Center" HorizontalOptions="Center" TextColor="{StaticResource PrimaryTextColor}" FontSize="10" FontAttributes="Bold" Style="{StaticResource BoldLabel}" />
+							<Label Text="{Binding AwardsCountValue}" HorizontalTextAlignment="Center" HorizontalOptions="Center" TextColor="{StaticResource SecondaryTextColor}" FontSize="24" FontAttributes="Bold" Style="{StaticResource BoldLabel}" />
+						</StackLayout>
+					</Grid>
 
-                    <ContentView Margin="0,40,0,0" Padding="0,20,0,20" BackgroundColor="{StaticResource BlueBackgroundColor}">
-                        <Label Margin="30,20,30,20" Text="{Binding Description}" HorizontalTextAlignment="Start" VerticalOptions="Center" TextColor="#FFFFFF" FontSize="14"></Label>
-                    </ContentView>
-                </StackLayout>
+					<ContentView BackgroundColor="{StaticResource BlueBackgroundColor}">
+						<Label Text="{Binding Description}" HorizontalTextAlignment="Start" VerticalOptions="Center" TextColor="#FFFFFF" FontSize="14"
+							   Margin="30,10,30,30"/>
+					</ContentView>
+				</StackLayout>
             </ScrollView>
         </Grid>
     </ContentPage.Content>

--- a/MVP/MVPUI/XamlResources/DataTemplates.xaml
+++ b/MVP/MVPUI/XamlResources/DataTemplates.xaml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms"
+                   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                   x:Class="Microsoft.Mvpui.XamlResources.DataTemplates">
+
+	<!-- TODO: Move listview datatemplate to resource dictionary - ContributionsPage -->
+	<!--<DataTemplate x:Key="ContributionListItemTemplate">
+	</DataTemplate>-->
+</ResourceDictionary>

--- a/MVP/MVPUI/XamlResources/DataTemplates.xaml.cs
+++ b/MVP/MVPUI/XamlResources/DataTemplates.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.Mvpui.XamlResources
+{
+	public partial class DataTemplates : Xamarin.Forms.ResourceDictionary
+	{
+		public DataTemplates()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/MVP/MVPUI/XamlResources/Styles.xaml
+++ b/MVP/MVPUI/XamlResources/Styles.xaml
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms"
+                   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                   x:Class="Microsoft.Mvpui.XamlResources.Styles">
+	<Color x:Key="Primary">#0072C6</Color>
+	<Color x:Key="PrimaryDark">#004f8a</Color>
+	<Color x:Key="Accent">#FFC107</Color>
+	<Color x:Key="BlueBackgroundColor">#0072C6</Color>
+	<Color x:Key="BackgroundColoriOS">#FFFFFF</Color>
+	<Color x:Key="NavigationTintColor">#999fa5</Color>
+	<Color x:Key="NavigationTitleColor">#0a77b2</Color>
+	<Color x:Key="NavigationShadowColor">#f2f2f2</Color>
+	<Color x:Key="TabTintColor">#0078d7</Color>
+	<Color x:Key="PrimaryTextColor">#818181</Color>
+	<Color x:Key="SecondaryTextColor">#4B4B4B</Color>
+
+	<OnPlatform x:Key="BackgroundColor" x:TypeArguments="Color">
+		<On Platform="iOS" Value="#FFFFFF" />
+		<On Platform="Android" Value="#F5F5F5" />
+		<On Platform="UWP" Value="#F5F5F5" />
+	</OnPlatform>
+	<OnPlatform x:Key="NormalLabelFontSize" x:TypeArguments="x:Double">
+		<On Platform="iOS" Value="13" />
+		<On Platform="Android" Value="14" />
+		<On Platform="UWP" Value="14" />
+	</OnPlatform>
+	<OnPlatform x:Key="BottomMenuLabelFontSize" x:TypeArguments="x:Double">
+		<On Platform="iOS" Value="10" />
+		<On Platform="Android" Value="12" />
+		<On Platform="UWP" Value="12" />
+	</OnPlatform>
+	<OnPlatform x:Key="ContributionBtnFontSize" x:TypeArguments="x:Double">
+		<On Platform="iOS" Value="10" />
+		<On Platform="Android" Value="16" />
+		<On Platform="UWP" Value="16" />
+	</OnPlatform>
+	<OnPlatform x:Key="CommonProfileLabelFontSize" x:TypeArguments="x:Double">
+		<On Platform="iOS" Value="12" />
+		<On Platform="Android" Value="14" />
+		<On Platform="UWP" Value="14" />
+	</OnPlatform>
+	<OnPlatform x:Key="SmallProfileLabelFontSize" x:TypeArguments="x:Double" >
+		<On Platform="iOS" Value="10" />
+		<On Platform="Android" Value="14" />
+		<On Platform="UWP" Value="14" />
+	</OnPlatform>
+	<OnPlatform x:Key="XSmallProfileLabelFontSize" x:TypeArguments="x:Double" >
+		<On Platform="iOS" Value="13" />
+		<On Platform="Android" Value="13" />
+		<On Platform="UWP" Value="13" />
+	</OnPlatform>
+
+	<Style TargetType="Label">
+		<Setter Property="FontFamily">
+			<Setter.Value>
+				<OnPlatform x:TypeArguments="x:String">
+					<OnPlatform.iOS>HelveticaNeue</OnPlatform.iOS>
+				</OnPlatform>
+			</Setter.Value>
+		</Setter>
+	</Style>
+	<Style TargetType="Button">
+		<Setter Property="FontFamily">
+			<Setter.Value>
+				<OnPlatform x:TypeArguments="x:String">
+					<OnPlatform.iOS>HelveticaNeue-Bold</OnPlatform.iOS>
+				</OnPlatform>
+			</Setter.Value>
+		</Setter>
+		<Setter Property="FontSize">
+			<Setter.Value>
+				<OnPlatform x:TypeArguments="x:Double">
+					<OnPlatform.iOS>14</OnPlatform.iOS>
+				</OnPlatform>
+			</Setter.Value>
+		</Setter>
+	</Style>
+	<Style TargetType="Label" x:Key="BoldLabel">
+		<Setter Property="FontFamily">
+			<Setter.Value>
+				<OnPlatform x:TypeArguments="x:String">
+					<OnPlatform.iOS>HelveticaNeue-Bold</OnPlatform.iOS>
+				</OnPlatform>
+			</Setter.Value>
+		</Setter>
+	</Style>
+</ResourceDictionary>

--- a/MVP/MVPUI/XamlResources/Styles.xaml.cs
+++ b/MVP/MVPUI/XamlResources/Styles.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.Mvpui.XamlResources
+{
+	public partial class Styles : Xamarin.Forms.ResourceDictionary
+	{
+		public Styles()
+		{
+			InitializeComponent();
+		}
+	}
+}


### PR DESCRIPTION
Small tweak to the profile page, so that desciption text has less white space. ( cfr. Old and New profile screenshots )

Enable merged resource dictionaries
This will allow us to separate Styles and DataTemplates to their own XAML file.

Already added the files, but the DataTemplate file is still empty. This because other open PR's would generate merge conflicts.

Will move the actual datatemplate of the profiles page as soon as the repo is fully merged again.
<img width="531" alt="new profile" src="https://user-images.githubusercontent.com/351693/34322319-40b0f96a-e824-11e7-89b6-fb35b6788ee9.png">
<img width="503" alt="old profile" src="https://user-images.githubusercontent.com/351693/34322320-40cdd9d6-e824-11e7-92a3-2b0be513b281.png">
