### PR TITLE
Close progress dialog when exception occurs

### DIFF
--- a/MVP/MVP/MVP/ViewModels/MyProfileViewModel.cs
+++ b/MVP/MVP/MVP/ViewModels/MyProfileViewModel.cs
@@ -401,15 +401,15 @@ namespace Microsoft.Mvp.ViewModels
 
 					List.AddRange(finalList);
 				}
+
 				CanLoadMore = contributions.Contributions.Count == 20;
+
+                progress?.Hide();
 			}
 			catch (Exception ex)
 			{
+                progress?.Hide();
 				await UserDialogs.Instance.AlertAsync(string.Format(TranslateServices.GetResourceString(CommonConstants.DialogDescriptionForCheckNetworkFormat1), ex.Message), TranslateServices.GetResourceString(CommonConstants.DialogOK));
-			}
-			finally
-			{
-				progress?.Hide();
 			}
 		}
 


### PR DESCRIPTION
Fixes #91
Hide the progress dialog as soon as an exception occurs. Otherwise we are not able to click on the close button.