### PR TITLE
Update labels to use reusable styles

### DIFF
--- a/MVP/MVPUI/ContributionDetail.xaml
+++ b/MVP/MVPUI/ContributionDetail.xaml
@@ -13,50 +13,50 @@
 				<StackLayout>
 					<StackLayout Padding="20">
 
-						<Label Text="{Binding LabelForContributionType}" FontSize="{StaticResource NormalLabelFontSize}" TextColor="{StaticResource SecondaryTextColor}" VerticalTextAlignment="End" />
+						<Label Text="{Binding LabelForContributionType}" Style="{StaticResource FormFieldHeaderLabel}" />
 						<Picker HeightRequest="40" x:Name="contributionTypeSelector" SelectedIndexChanged="OnContributionTypeSelectedIndexChanged" />
 
-						<Label Text="{Binding LabelForContributionArea}" FontSize="{StaticResource NormalLabelFontSize}"  TextColor="{StaticResource SecondaryTextColor}" VerticalTextAlignment="End" />
+						<Label Text="{Binding LabelForContributionArea}" Style="{StaticResource FormFieldHeaderLabel}" />
 						<Picker HeightRequest="40"  x:Name="ContributionAreaSelector" TextColor="Black" />
 
-						<Label Text="{Binding LabelForContributionDate}" FontSize="{StaticResource NormalLabelFontSize}"  TextColor="{StaticResource SecondaryTextColor}" VerticalTextAlignment="End" />
+						<Label Text="{Binding LabelForContributionDate}" Style="{StaticResource FormFieldHeaderLabel}" />
 						<DatePicker x:Name="ContributionDateSelector" Date="{Binding MyContribution.StartDate}" TextColor="Black" />
 
 						<StackLayout Spacing="0" Orientation="Horizontal">
-							<Label Text="{Binding LabelForContributionTitle}" FontSize="{StaticResource NormalLabelFontSize}"  TextColor="{StaticResource SecondaryTextColor}" VerticalTextAlignment="End" />
-							<Label Text="{Binding ErrorMessageForTitle}"  FontSize="{StaticResource NormalLabelFontSize}" TextColor="Red" VerticalTextAlignment="End" />
+							<Label Text="{Binding LabelForContributionTitle}" Style="{StaticResource FormFieldHeaderLabel}" />
+							<Label Text="{Binding ErrorMessageForTitle}"   Style="{StaticResource FormFieldErrorHeaderLabel}" />
 						</StackLayout>
 						<Entry  x:Name="entryTitle" Text="{Binding MyContribution.Title}" TextColor="Black" />
 
-						<Label Text="{Binding LabelForVisibility}" FontSize="{StaticResource NormalLabelFontSize}" TextColor="{StaticResource SecondaryTextColor}" VerticalTextAlignment="End" />
+						<Label Text="{Binding LabelForVisibility}"  Style="{StaticResource FormFieldHeaderLabel}" />
 						<Picker x:Name="PersonGroupSelector" TextColor="Black" />
 
 						<StackLayout Spacing="0" Orientation="Horizontal">
-							<Label Text="{Binding LabelForURL}" FontSize="{StaticResource NormalLabelFontSize}"  TextColor="{StaticResource SecondaryTextColor}" VerticalTextAlignment="End" />
-							<Label Text="{Binding ErrorMessageForUrl}" FontSize="{StaticResource NormalLabelFontSize}" TextColor="Red" IsVisible="{Binding IsNeededUrl}" VerticalTextAlignment="End" />
+							<Label Text="{Binding LabelForURL}" Style="{StaticResource FormFieldHeaderLabel}" />
+							<Label Text="{Binding ErrorMessageForUrl}"  Style="{StaticResource FormFieldErrorHeaderLabel}" IsVisible="{Binding IsNeededUrl}" />
 						</StackLayout>
 						<Entry x:Name="entryURL" Keyboard="Url" TextColor="Black" Text="{Binding MyContribution.ReferenceUrl}" />
 
-						<Label Text="{Binding LabelForDescription}" FontSize="{StaticResource NormalLabelFontSize}" TextColor="{StaticResource SecondaryTextColor}" VerticalTextAlignment="End" />
+						<Label Text="{Binding LabelForDescription}"  Style="{StaticResource FormFieldHeaderLabel}" />
 						<Editor HeightRequest="180" BackgroundColor="#10000000" x:Name="entryDescription" TextColor="Black" Text="{Binding MyContribution.Description}" />
 
 						<StackLayout Spacing="0" Orientation="Horizontal">
-							<Label FontSize="{StaticResource NormalLabelFontSize}" Text="{Binding AnnualQuantityTipText}"  TextColor="{StaticResource SecondaryTextColor}" VerticalTextAlignment="End" />
-							<Label FontSize="{StaticResource NormalLabelFontSize}" Text="{Binding ErrorMessageForAnnualQuantity}" TextColor="Red" IsVisible="{Binding IsNeededAnnualQuantity}" VerticalTextAlignment="End" />
+							<Label Text="{Binding AnnualQuantityTipText}" Style="{StaticResource FormFieldHeaderLabel}" />
+							<Label Text="{Binding ErrorMessageForAnnualQuantity}" Style="{StaticResource FormFieldErrorHeaderLabel}" IsVisible="{Binding IsNeededAnnualQuantity}" />
 						</StackLayout>
 						<Entry x:Name="entryAnnualQuantity" Keyboard="Numeric" TextColor="Black" Text="{Binding MyContribution.AnnualQuantity}" />
 
 						<StackLayout IsVisible="{Binding IsNeededSecondAnnualQuantity}">
 							<StackLayout Spacing="0" Orientation="Horizontal">
-								<Label FontSize="{StaticResource NormalLabelFontSize}" Text="{Binding SecondAnnualQuantityTipText}" TextColor="{StaticResource SecondaryTextColor}" VerticalTextAlignment="End" />
-								<Label FontSize="{StaticResource NormalLabelFontSize}" Text="{Binding ErrorMessageForSecondAnnualQuantity}" TextColor="Red" VerticalTextAlignment="End" />
+								<Label Text="{Binding SecondAnnualQuantityTipText}" Style="{StaticResource FormFieldHeaderLabel}" />
+								<Label Text="{Binding ErrorMessageForSecondAnnualQuantity}"  Style="{StaticResource FormFieldErrorHeaderLabel}" />
 							</StackLayout>
 							<Entry x:Name="entrySecondAnnualQuantity" Keyboard="Numeric" TextColor="Black" Text="{Binding MyContribution.SecondAnnualQuantity}" />
 						</StackLayout>
 
 						<StackLayout Spacing="0" Orientation="Horizontal">
-							<Label FontSize="{StaticResource NormalLabelFontSize}" Text="{Binding AnnualReachTipText}"  TextColor="{StaticResource SecondaryTextColor}" VerticalTextAlignment="End" />
-							<Label FontSize="{StaticResource NormalLabelFontSize}" Text="{Binding ErrorMessageForAnnualReach}" TextColor="Red" VerticalTextAlignment="End" />
+							<Label Text="{Binding AnnualReachTipText}" Style="{StaticResource FormFieldHeaderLabel}" />
+							<Label Text="{Binding ErrorMessageForAnnualReach}" Style="{StaticResource FormFieldErrorHeaderLabel}" />
 						</StackLayout>
 						<Entry x:Name="entryAnnualReach" Keyboard="Numeric" TextColor="Black" Text="{Binding MyContribution.AnnualReach}" />
 

--- a/MVP/MVPUI/ContributionsPage.xaml
+++ b/MVP/MVPUI/ContributionsPage.xaml
@@ -57,15 +57,11 @@
 
 									<StackLayout Orientation="Horizontal"
 												 Grid.Row="2">
-										<Label Text="{Binding DataFormat}" TextColor="{StaticResource PrimaryTextColor}"
-											   FontSize="{StaticResource XSmallProfileLabelFontSize}" />
-										<Label Text="|" TextColor="{StaticResource PrimaryTextColor}"
-											   FontSize="{StaticResource XSmallProfileLabelFontSize}" />
+										<Label Text="{Binding DataFormat}" Style="{StaticResource CellSmallLabel}" />
+										<Label Text="|" Style="{StaticResource CellSmallLabel}" />
 										<StackLayout Orientation="Horizontal">
-											<Label Text="{Binding LabelTextOfContribution, Converter={StaticResource TranslateExtensionConverter}}"
-												   TextColor="{StaticResource PrimaryTextColor}" FontSize="{StaticResource XSmallProfileLabelFontSize}" />
-											<Label Text="{Binding AnnualReach}" TextColor="{StaticResource PrimaryTextColor}"
-												   FontSize="{StaticResource XSmallProfileLabelFontSize}" />
+											<Label Text="{Binding LabelTextOfContribution, Converter={StaticResource TranslateExtensionConverter}}" Style="{StaticResource CellSmallLabel}" />
+											<Label Text="{Binding AnnualReach}"  Style="{StaticResource CellSmallLabel}" />
 										</StackLayout>
 									</StackLayout>
 								</Grid>

--- a/MVP/MVPUI/XamlResources/Styles.xaml
+++ b/MVP/MVPUI/XamlResources/Styles.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms"
                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                    x:Class="Microsoft.Mvpui.XamlResources.Styles">
@@ -83,5 +83,17 @@
 				</OnPlatform>
 			</Setter.Value>
 		</Setter>
+	</Style>
+	<Style TargetType="Label" x:Key="FormFieldHeaderLabel">
+		<Setter Property="FontSize"  Value="{StaticResource NormalLabelFontSize}" />
+		<Setter Property="TextColor"  Value="{StaticResource SecondaryTextColor}" />
+		<Setter Property="VerticalTextAlignment"  Value="End" />
+	</Style>
+	<Style TargetType="Label" x:Key="FormFieldErrorHeaderLabel" BasedOn="{StaticResource FormFieldHeaderLabel}" >
+		<Setter Property="TextColor" Value="Red" />
+	</Style>
+	<Style TargetType="Label" x:Key="CellSmallLabel">
+		<Setter Property="TextColor"  Value="{StaticResource PrimaryTextColor}" />
+		<Setter Property="FontSize"  Value="{StaticResource XSmallProfileLabelFontSize}" />
 	</Style>
 </ResourceDictionary>


### PR DESCRIPTION
For labels that where setting the same properties multiple times, those properties have been moved into reusable styles that can be used across the app consistently